### PR TITLE
Update to add dispatch to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,8 @@
 name: release
 
 on:
+  repository_dispatch:
+    types: [release]
   push:
     branches:
       - main


### PR DESCRIPTION
This is needed due to the action-validate-check workflow  it will call release when a new release of action-validate-image has been created. fixed: EC-110
signed off Sean Conroy sconroy@redhat.com